### PR TITLE
add option to remove quotes from copied json string

### DIFF
--- a/lua/copy-path/init.lua
+++ b/lua/copy-path/init.lua
@@ -12,13 +12,18 @@ local function get_current_node()
     return current_node
 end
 
-local function traversed_nodes_to_path(traversed_nodes)
+local function traversed_nodes_to_path(traversed_nodes, remove_quotes)
     local path = ""
     for i = #traversed_nodes, 1, -1 do
         path = path .. traversed_nodes[i]
         if i ~= 1 then path = path .. "." end
     end
-    return string.gsub(path, "%.%[", "[")
+
+    if not remove_quotes then
+        return string.gsub(path, "%.%[", "[")
+    end
+
+    return string.gsub(string.gsub(path, "%.%[", "["), '"', "")
 end
 
 local M = {}
@@ -62,7 +67,7 @@ M.copy_json_path = function(args)
         current_node = current_node:parent()
     end
 
-    local path = traversed_nodes_to_path(traversed_nodes)
+    local path = traversed_nodes_to_path(traversed_nodes, args.remove_quotes)
     vim.fn.setreg(register, path)
     print("Path " .. path .. " copied to register " .. register)
 end


### PR DESCRIPTION
adding an optional argument to remove quotes from copied keys (i.e. `foo.bar` instead of `"foo"."bar"`) to more easily use the path as a translation key